### PR TITLE
Simplify setup of infra-ansible by using a virtualenv that does not require root privs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@ Instructions
 ============
 
 1. Run ``bash setup_env.sh``
-2. Run ``source /opt/stack/ansible/hacking/env-setup``
 3. Source your OpenStack cloud environment variables rc file
 3. Run ``cp infra_config.yml.sample infra_config.yml``
 4. Edit infra_config.yml and put your environment values

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 ansible-playbook -i hosts provision_infra_servers.yml -e "@infra_config.yml"
-ansible-playbook -i /opt/stack/ansible/contrib/inventory/openstack.py site.yml -e "@infra_config.yml"
+ansible-playbook -i ansible/contrib/inventory/openstack.py site.yml -e "@infra_config.yml"


### PR DESCRIPTION
Add the ability to install all the dependencies needed for infra-ansible to run in a virtualenv as a non-root user.
